### PR TITLE
Fix for AMB_HTTP_ENDPOINT not getting prefixed

### DIFF
--- a/contract/hardhat.config.js
+++ b/contract/hardhat.config.js
@@ -2,9 +2,32 @@ const AWSHttpProvider = require('@aws/web3-http-provider');
 require('@nomiclabs/hardhat-ethers');
 require('@nomiclabs/hardhat-web3');
 
+const getAmbEndpoint = () => {
+  if (!process.env.AMB_HTTP_ENDPOINT) {
+    console.error(`Environment variable AMB_HTTP_ENDPOINT is not set.
+
+Add the AMB_HTTP_ENDPOINT by running the following, replacing <node id> and <region>
+with your AMB node ID and region, respectively.
+
+\`\`\`
+export AMB_HTTP_ENDPOINT=https://<node id>.ethereum.managedblockchain.<region>.amazonaws.com
+\`\`\`
+`)
+  }
+  // The AWS console copies the endpoint without the required https:// prefix
+  if (!process.env.AMB_HTTP_ENDPOINT.startsWith('https://')) {
+    // Add https:// prefix if it doesn't already exist
+    console.debug('Adding https:// prefix to AMB_HTTP_ENDPOINT');
+    return `https://${process.env.AMB_HTTP_ENDPOINT}`;
+  } else {
+    return process.env.AMB_HTTP_ENDPOINT;
+  }
+}
+
+
 extendEnvironment((hre) => {
   if (hre.network.name === 'amb') {
-    const endpoint = process.env.AMB_HTTP_ENDPOINT;
+    const endpoint = getAmbEndpoint();
     const Web3 = require('web3');
     hre.Web3 = Web3;
     hre.web3 = new Web3(new AWSHttpProvider(endpoint));

--- a/contract/scripts/deploy-amb.js
+++ b/contract/scripts/deploy-amb.js
@@ -1,9 +1,3 @@
-// The AWS console copies the endpoint without the required https:// prefix
-if (process.env.AMB_HTTP_ENDPOINT && !process.env.AMB_HTTP_ENDPOINT.startsWith('https://')) {
-  // Add https:// prefix if it doesn't already exist
-  process.env.AMB_HTTP_ENDPOINT = `https://${process.env.AMB_HTTP_ENDPOINT}`
-}
-
 const hardhat = require('hardhat');
 const path = require('path');
 const SimpleERC721 = require(path.join(__dirname, '..', 'artifacts', 'contracts', 'SimpleERC721.sol', 'SimpleERC721.json'));

--- a/docs/en/DOCS_02_DEPLOY_CONTRACT.md
+++ b/docs/en/DOCS_02_DEPLOY_CONTRACT.md
@@ -133,10 +133,10 @@ to the `Address` we just created.
 After the deposit is complete, run the following command to ste up an account to
 deploy the contract.
 
-Replace `<0x ...>` with the contents of `PrivateKey` from the previous step.
+Replace `<0x...>` with the contents of `PrivateKey` from the previous step.
 
 ```bash
-export PRIVATE_KEY='<0x ...>'
+export PRIVATE_KEY='<0x...>'
 ```
 
 Next, set up AWS IAM permissions to connect to the Amazon Managed Blockchain if
@@ -146,8 +146,8 @@ Secret Access Key in your environment variables as follows: Each `<...>` needs
 to be replaced with the appropriate value.
 
 ```bash
-export AWS_ACCESS_KEY_ID = <...>
-export AWS_SECRET_ACCESS_KEY = <...>
+export AWS_ACCESS_KEY_ID='<...>'
+export AWS_SECRET_ACCESS_KEY='<...>'
 ```
 
 **IMPORTANT**: These access key environment variables must currently be set until


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change fixes an issue where the `AMB_HTTP_ENDPOINT` wouldn't be prefixed if it was missing `https://`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
